### PR TITLE
Add paragraph style rules to Global.style.ts

### DIFF
--- a/src/styles/Global.style.ts
+++ b/src/styles/Global.style.ts
@@ -224,6 +224,10 @@ const GlobalStyles = createGlobalStyle`
         border-block-end: 4px solid var(--teal-50);
         border-radius: 4px;
     }
+    p {
+        overflow-wrap: break-word;
+        hyphens: auto;
+    }
 `;
 
 export default GlobalStyles;


### PR DESCRIPTION
Added 'overflow-wrap' and 'hyphens' CSS properties to the paragraph tag in the GlobalStyle file. This will ensure that long words will break and hyphenate correctly, improving readability across different screen sizes.